### PR TITLE
API Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*__pycache__*
 .idea*

--- a/rest/client.py
+++ b/rest/client.py
@@ -65,8 +65,8 @@ class FtxClient:
     def get_account_info(self) -> dict:
         return self._get(f'account')
 
-    def get_open_orders(self) -> List[dict]:
-        return self._get(f'orders')
+    def get_open_orders(self, market_name: str = None) -> List[dict]:
+        return self._get(f'orders', {'market': market_name})
 
     def get_conditional_orders(self, market_name: str) -> List[dict]:
         return self._get(f'conditional_orders', {'market': market_name})

--- a/rest/client.py
+++ b/rest/client.py
@@ -88,3 +88,9 @@ class FtxClient:
 
     def get_deposit_address(self, ticker: str) -> dict:
         return self._get(f'wallet/deposit_address/{ticker}')
+
+    def get_positions(self) -> List[dict]:
+        return self._get('positions')
+
+    def get_position(self, name: str) -> dict:
+        return next(filter(lambda x: x['future'] == name, self.get_positions()), None)

--- a/rest/client.py
+++ b/rest/client.py
@@ -74,9 +74,10 @@ class FtxClient:
     def get_conditional_orders(self, market_name: str) -> List[dict]:
         return self._get(f'conditional_orders', {'market': market_name})
 
-    def place_order(self, future: str, side: str, price: float, size: float, type: str,
-                    reduce_only: bool = False, ioc: bool = False, post_only: bool = False) -> dict:
-        return self._post('orders', {'future': future,
+    def place_order(self, market: str, side: str, price: float, size: float, type: str,
+                    reduce_only: bool = False, ioc: bool = False, post_only: bool = False,
+                    client_id: str = None) -> dict:
+        return self._post('orders', {'market': market,
                                      'side': side,
                                      'price': price,
                                      'size': size,
@@ -84,13 +85,18 @@ class FtxClient:
                                      'reduceOnly': reduce_only,
                                      'ioc': ioc,
                                      'postOnly': post_only,
+                                     'clientId': client_id,
                                      })
 
-    def market_order(self, future: str, side: str, size: float, reduce_only: bool = False) -> dict:
-        return self.place_order(future, side, None, size, 'market', reduce_only)
+    def market_order(self, market: str, side: str, size: float, reduce_only: bool = False, ioc: bool = False,
+                     post_only: bool = False,
+                     client_id: str = None) -> dict:
+        return self.place_order(market, side, None, size, 'market', reduce_only, ioc, post_only, client_id)
 
-    def limit_order(self, future: str, side: str, price: float, size: float, reduce_only: bool = False) -> dict:
-        return self.place_order(future, side, price, size, 'limit', reduce_only)
+    def limit_order(self, market: str, side: str, price: float, size: float, reduce_only: bool = False,
+                    ioc: bool = False, post_only: bool = False,
+                    client_id: str = None) -> dict:
+        return self.place_order(market, side, price, size, 'limit', reduce_only, ioc, post_only, client_id)
 
     def stop_limit_order(self, market: str, side: str, trigger_price: float, order_price: float, size: float,
                          reduce_only: bool = False, cancel: bool = True) -> dict:

--- a/rest/client.py
+++ b/rest/client.py
@@ -131,8 +131,8 @@ class FtxClient:
     def get_deposit_address(self, ticker: str) -> dict:
         return self._get(f'wallet/deposit_address/{ticker}')
 
-    def get_positions(self) -> List[dict]:
-        return self._get('positions')
+    def get_positions(self, show_avg_price: bool = False) -> List[dict]:
+        return self._get('positions', {'showAvgPrice': show_avg_price})
 
-    def get_position(self, name: str) -> dict:
-        return next(filter(lambda x: x['future'] == name, self.get_positions()), None)
+    def get_position(self, name: str, show_avg_price: bool = False) -> dict:
+        return next(filter(lambda x: x['future'] == name, self.get_positions(show_avg_price)), None)

--- a/rest/client.py
+++ b/rest/client.py
@@ -68,11 +68,11 @@ class FtxClient:
     def get_account_info(self) -> dict:
         return self._get(f'account')
 
-    def get_open_orders(self, market_name: str = None) -> List[dict]:
-        return self._get(f'orders', {'market': market_name})
+    def get_open_orders(self, market: str = None) -> List[dict]:
+        return self._get(f'orders', {'market': market})
 
-    def get_conditional_orders(self, market_name: str) -> List[dict]:
-        return self._get(f'conditional_orders', {'market': market_name})
+    def get_conditional_orders(self, market: str = None) -> List[dict]:
+        return self._get(f'conditional_orders', {'market': market})
 
     def place_order(self, market: str, side: str, price: float, size: float, type: str,
                     reduce_only: bool = False, ioc: bool = False, post_only: bool = False,

--- a/rest/client.py
+++ b/rest/client.py
@@ -20,8 +20,8 @@ class FtxClient:
     def _post(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         return self._request('POST', path, json=params)
 
-    def _delete(self, path: str) -> Any:
-        return self._request('DELETE', path)
+    def _delete(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        return self._request('DELETE', path, params=params)
 
     def _request(self, method: str, path: str, **kwargs) -> Any:
         request = Request(method, self._ENDPOINT + path, **kwargs)
@@ -102,6 +102,9 @@ class FtxClient:
 
     def cancel_order(self, order_id: str) -> dict:
         return self._delete(f'orders/{order_id}')
+
+    def cancel_orders(self, market_name: str = None) -> dict:
+        return self._delete(f'orders', {'market': market_name})
 
     def get_fills(self) -> List[dict]:
         return self._get(f'fills')

--- a/rest/client.py
+++ b/rest/client.py
@@ -68,6 +68,9 @@ class FtxClient:
     def get_open_orders(self) -> List[dict]:
         return self._get(f'orders')
 
+    def get_conditional_orders(self, market_name: str) -> List[dict]:
+        return self._get(f'conditional_orders', {'market': market_name})
+
     def place_order(self, future: str, side: str, price: float, size: float, type: str,
                     reduce_only: bool = False) -> dict:
         return self._post('orders', {'future': future,

--- a/rest/client.py
+++ b/rest/client.py
@@ -12,6 +12,7 @@ class FtxClient:
         self._session = Session()
         self._api_key = '' # TODO: Place your API key here
         self._api_secret = '' # TODO: Place your API secret here
+        self.ftx_sub_account = None
 
     def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         return self._request('GET', path, params=params)
@@ -38,6 +39,9 @@ class FtxClient:
         request.headers['FTX-KEY'] = self._api_key
         request.headers['FTX-SIGN'] = signature
         request.headers['FTX-TS'] = str(ts)
+        if self.ftx_sub_account:
+            request.headers['FTX-SUBACCOUNT'] = self.ftx_sub_account
+
 
     def _process_response(self, response: Response) -> Any:
         try:

--- a/rest/client.py
+++ b/rest/client.py
@@ -8,11 +8,11 @@ import hmac
 class FtxClient:
     _ENDPOINT = 'https://ftx.com/api/'
 
-    def __init__(self, api_key=None, api_secret=None, ftx_sub_account=None) -> None:
+    def __init__(self, api_key=None, api_secret=None, subaccount_name=None) -> None:
         self._session = Session()
-        self.api_key = api_key
-        self.api_secret = api_secret
-        self.ftx_sub_account = ftx_sub_account
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._subaccount_name = subaccount_name
 
     def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         return self._request('GET', path, params=params)
@@ -35,12 +35,12 @@ class FtxClient:
         signature_payload = f'{ts}{prepared.method}{prepared.path_url}'.encode()
         if prepared.body:
             signature_payload += prepared.body
-        signature = hmac.new(self.api_secret.encode(), signature_payload, 'sha256').hexdigest()
-        request.headers['FTX-KEY'] = self.api_key
+        signature = hmac.new(self._api_secret.encode(), signature_payload, 'sha256').hexdigest()
+        request.headers['FTX-KEY'] = self._api_key
         request.headers['FTX-SIGN'] = signature
         request.headers['FTX-TS'] = str(ts)
-        if self.ftx_sub_account:
-            request.headers['FTX-SUBACCOUNT'] = self.ftx_sub_account
+        if self._subaccount_name:
+            request.headers['FTX-SUBACCOUNT'] = self._subaccount_name
 
     def _process_response(self, response: Response) -> Any:
         try:

--- a/rest/client.py
+++ b/rest/client.py
@@ -21,7 +21,7 @@ class FtxClient:
         return self._request('POST', path, json=params)
 
     def _delete(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
-        return self._request('DELETE', path, params=params)
+        return self._request('DELETE', path, json=params)
 
     def _request(self, method: str, path: str, **kwargs) -> Any:
         request = Request(method, self._ENDPOINT + path, **kwargs)

--- a/rest/client.py
+++ b/rest/client.py
@@ -103,8 +103,12 @@ class FtxClient:
     def cancel_order(self, order_id: str) -> dict:
         return self._delete(f'orders/{order_id}')
 
-    def cancel_orders(self, market_name: str = None) -> dict:
-        return self._delete(f'orders', {'market': market_name})
+    def cancel_orders(self, market_name: str = None, conditional_orders: bool = False,
+                      limit_orders: bool = False) -> dict:
+        return self._delete(f'orders', {'market': market_name,
+                                        'conditionalOrdersOnly': conditional_orders,
+                                        'limitOrdersOnly': limit_orders,
+                                        })
 
     def get_fills(self) -> List[dict]:
         return self._get(f'fills')

--- a/rest/client.py
+++ b/rest/client.py
@@ -8,11 +8,11 @@ import hmac
 class FtxClient:
     _ENDPOINT = 'https://ftx.com/api/'
 
-    def __init__(self) -> None:
+    def __init__(self, api_key=None, api_secret=None, ftx_sub_account=None) -> None:
         self._session = Session()
-        self._api_key = '' # TODO: Place your API key here
-        self._api_secret = '' # TODO: Place your API secret here
-        self.ftx_sub_account = None
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.ftx_sub_account = ftx_sub_account
 
     def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         return self._request('GET', path, params=params)
@@ -35,13 +35,12 @@ class FtxClient:
         signature_payload = f'{ts}{prepared.method}{prepared.path_url}'.encode()
         if prepared.body:
             signature_payload += prepared.body
-        signature = hmac.new(self._api_secret.encode(), signature_payload, 'sha256').hexdigest()
-        request.headers['FTX-KEY'] = self._api_key
+        signature = hmac.new(self.api_secret.encode(), signature_payload, 'sha256').hexdigest()
+        request.headers['FTX-KEY'] = self.api_key
         request.headers['FTX-SIGN'] = signature
         request.headers['FTX-TS'] = str(ts)
         if self.ftx_sub_account:
             request.headers['FTX-SUBACCOUNT'] = self.ftx_sub_account
-
 
     def _process_response(self, response: Response) -> Any:
         try:

--- a/rest/client.py
+++ b/rest/client.py
@@ -74,7 +74,7 @@ class FtxClient:
     def get_conditional_orders(self, market: str = None) -> List[dict]:
         return self._get(f'conditional_orders', {'market': market})
 
-    def place_order(self, market: str, side: str, price: float, size: float, type: str,
+    def place_order(self, market: str, side: str, price: float, size: float, type: str = 'limit',
                     reduce_only: bool = False, ioc: bool = False, post_only: bool = False,
                     client_id: str = None) -> dict:
         return self._post('orders', {'market': market,

--- a/rest/client.py
+++ b/rest/client.py
@@ -77,6 +77,14 @@ class FtxClient:
                                      'type': type,
                                      'reduceOnly': reduce_only})
 
+    def market_order(self, future: str, side: str, size: float, reduce_only: bool = False) -> dict:
+        return self._post('orders', {'future': future,
+                                     'side': side,
+                                     'price': None,
+                                     'size': size,
+                                     'type': 'market',
+                                     'reduceOnly': reduce_only})
+
     def cancel_order(self, order_id: str) -> dict:
         return self._delete(f'orders/{order_id}')
 

--- a/rest/client.py
+++ b/rest/client.py
@@ -88,19 +88,12 @@ class FtxClient:
                                      'clientId': client_id,
                                      })
 
-    def stop_limit_order(self, market: str, side: str, trigger_price: float, order_price: float, size: float,
+    def place_conditional_order(self, market: str, side: str, trigger_price: float, size: float, order_price: float,
                          reduce_only: bool = False, cancel: bool = True) -> dict:
         return self._post('conditional_orders',
                           {'market': market, 'side': side, 'triggerPrice': trigger_price, 'size': size,
                            'reduceOnly': reduce_only, 'type': 'stop', 'cancelLimitOnTrigger': cancel,
                            'orderPrice': order_price})
-
-    def stop_market_order(self, market: str, side: str, trigger_price: float, size: float, reduce_only: bool = False,
-                          cancel: bool = True) -> dict:
-        return self._post('conditional_orders',
-                          {'market': market, 'side': side, 'triggerPrice': trigger_price, 'size': size,
-                           'reduceOnly': reduce_only, 'type': 'stop', 'cancelLimitOnTrigger': cancel,
-                           'orderPrice': None})
 
     def cancel_order(self, order_id: str) -> dict:
         return self._delete(f'orders/{order_id}')

--- a/rest/client.py
+++ b/rest/client.py
@@ -88,16 +88,6 @@ class FtxClient:
                                      'clientId': client_id,
                                      })
 
-    def market_order(self, market: str, side: str, size: float, reduce_only: bool = False, ioc: bool = False,
-                     post_only: bool = False,
-                     client_id: str = None) -> dict:
-        return self.place_order(market, side, None, size, 'market', reduce_only, ioc, post_only, client_id)
-
-    def limit_order(self, market: str, side: str, price: float, size: float, reduce_only: bool = False,
-                    ioc: bool = False, post_only: bool = False,
-                    client_id: str = None) -> dict:
-        return self.place_order(market, side, price, size, 'limit', reduce_only, ioc, post_only, client_id)
-
     def stop_limit_order(self, market: str, side: str, trigger_price: float, order_price: float, size: float,
                          reduce_only: bool = False, cancel: bool = True) -> dict:
         return self._post('conditional_orders',

--- a/rest/client.py
+++ b/rest/client.py
@@ -69,11 +69,13 @@ class FtxClient:
     def get_open_orders(self) -> List[dict]:
         return self._get(f'orders')
 
-    def place_order(self, future: str, side: str, price: float, size: float) -> dict:
+    def place_order(self, future: str, side: str, price: float, size: float, type: str, reduce_only: bool = False) -> dict:
         return self._post('orders', {'future': future,
                                      'side': side,
                                      'price': price,
-                                     'size': size})
+                                     'size': size,
+                                     'type': type,
+                                     'reduceOnly': reduce_only})
 
     def cancel_order(self, order_id: str) -> dict:
         return self._delete(f'orders/{order_id}')

--- a/rest/client.py
+++ b/rest/client.py
@@ -59,8 +59,8 @@ class FtxClient:
     def list_markets(self) -> List[dict]:
         return self._get('markets')
 
-    def get_orderbook(self, market: str) -> dict:
-        return self._get(f'markets/{market}/orderbook', {'depth': 100})
+    def get_orderbook(self, market: str, depth: int = None) -> dict:
+        return self._get(f'markets/{market}/orderbook', {'depth': depth})
 
     def get_trades(self, market: str) -> dict:
         return self._get(f'markets/{market}/trades')

--- a/rest/client.py
+++ b/rest/client.py
@@ -68,7 +68,8 @@ class FtxClient:
     def get_open_orders(self) -> List[dict]:
         return self._get(f'orders')
 
-    def place_order(self, future: str, side: str, price: float, size: float, type: str, reduce_only: bool = False) -> dict:
+    def place_order(self, future: str, side: str, price: float, size: float, type: str,
+                    reduce_only: bool = False) -> dict:
         return self._post('orders', {'future': future,
                                      'side': side,
                                      'price': price,
@@ -77,12 +78,24 @@ class FtxClient:
                                      'reduceOnly': reduce_only})
 
     def market_order(self, future: str, side: str, size: float, reduce_only: bool = False) -> dict:
-        return self._post('orders', {'future': future,
-                                     'side': side,
-                                     'price': None,
-                                     'size': size,
-                                     'type': 'market',
-                                     'reduceOnly': reduce_only})
+        return self.place_order(future, side, None, size, 'market', reduce_only)
+
+    def limit_order(self, future: str, side: str, price: float, size: float, reduce_only: bool = False) -> dict:
+        return self.place_order(future, side, price, size, 'limit', reduce_only)
+
+    def stop_limit_order(self, market: str, side: str, trigger_price: float, order_price: float, size: float,
+                         reduce_only: bool = False, cancel: bool = True) -> dict:
+        return self._post('conditional_orders',
+                          {'market': market, 'side': side, 'triggerPrice': trigger_price, 'size': size,
+                           'reduceOnly': reduce_only, 'type': 'stop', 'cancelLimitOnTrigger': cancel,
+                           'orderPrice': order_price})
+
+    def stop_market_order(self, market: str, side: str, trigger_price: float, size: float, reduce_only: bool = False,
+                          cancel: bool = True) -> dict:
+        return self._post('conditional_orders',
+                          {'market': market, 'side': side, 'triggerPrice': trigger_price, 'size': size,
+                           'reduceOnly': reduce_only, 'type': 'stop', 'cancelLimitOnTrigger': cancel,
+                           'orderPrice': None})
 
     def cancel_order(self, order_id: str) -> dict:
         return self._delete(f'orders/{order_id}')


### PR DESCRIPTION
- Add sub account param.
- Change init to accept api params.  Methods don't need to imply private as account details can be changed at runtime.
- Added more endpoints; get positions, conditional orders, stops.  Add extra params to some methods.  Add clearer helper methods for market/limit orders.
