### PR TITLE
Add OpenSSL 1.1.x support (detection and API changes)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,6 +14,9 @@ find_package(Boost 1.71 REQUIRED)
 link_directories(${Boost_LIBRARY_DIRS})
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
+find_package(OpenSSL 1.1 REQUIRED)
+include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
+
 include_directories(src)
 include_directories(SYSTEM src/external)
 

--- a/cpp/src/example/CMakeLists.txt
+++ b/cpp/src/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(rest_test rest_test.cc)
-target_link_libraries(rest_test ssl crypto rest util ${Boost_LIBRARIES})
+target_link_libraries(rest_test OpenSSL::SSL OpenSSL::Crypto rest util ${Boost_LIBRARIES})
 
 add_executable(ws_test ws_test.cc)
-target_link_libraries(ws_test ssl crypto ws util ${Boost_LIBRARIES})
+target_link_libraries(ws_test OpenSSL::SSL OpenSSL::Crypto ws util ${Boost_LIBRARIES})

--- a/cpp/src/util/CMakeLists.txt
+++ b/cpp/src/util/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(GLOB SOURCES "*cc")
 add_library(util STATIC ${SOURCES})
 target_include_directories(util PUBLIC)
-target_link_libraries(util ssl crypto)
+
+target_link_libraries(util OpenSSL::SSL OpenSSL::Crypto)

--- a/cpp/src/util/Encoding.h
+++ b/cpp/src/util/Encoding.h
@@ -8,9 +8,9 @@ namespace util::encoding {
 namespace {
 struct HmacCtx
 {
-    HMAC_CTX ctx;
-    HmacCtx() { HMAC_CTX_init(&ctx); }
-    ~HmacCtx() { HMAC_CTX_cleanup(&ctx); }
+    HMAC_CTX *ctx;
+    HmacCtx() { ctx = HMAC_CTX_new(); }
+    ~HmacCtx() { HMAC_CTX_free(ctx); }
 };
 }
 
@@ -22,9 +22,9 @@ std::string hmac(const std::string& secret,
     char signed_msg[64];
 
     HMAC_Init_ex(
-      &hmac.ctx, secret.data(), (int)secret.size(), EVP_sha256(), nullptr);
-    HMAC_Update(&hmac.ctx, (unsigned char*)msg.data(), msg.size());
-    HMAC_Final(&hmac.ctx, (unsigned char*)signed_msg, nullptr);
+      hmac.ctx, secret.data(), (int)secret.size(), EVP_sha256(), nullptr);
+    HMAC_Update(hmac.ctx, (unsigned char*)msg.data(), msg.size());
+    HMAC_Final(hmac.ctx, (unsigned char*)signed_msg, nullptr);
 
     return {signed_msg, signed_len};
 }
@@ -48,7 +48,7 @@ constexpr char hexmap[] = {'0',
                            'f'};
 }
 
-std::string string_to_hex(unsigned char* data, std::size_t len)
+std::string util_string_to_hex(unsigned char* data, std::size_t len)
 {
     std::string s(len * 2, ' ');
     for (std::size_t i = 0; i < len; ++i) {

--- a/cpp/src/util/HTTP.cc
+++ b/cpp/src/util/HTTP.cc
@@ -107,7 +107,7 @@ void HTTPSession::authenticate(http::request<http::string_body>& req)
     }
     std::string hmacced = encoding::hmac(std::string(api_secret), data, 32);
     std::string sign =
-      encoding::string_to_hex((unsigned char*)hmacced.c_str(), 32);
+      encoding::util_string_to_hex((unsigned char*)hmacced.c_str(), 32);
 
     req.set("FTX-KEY", api_key);
     req.set("FTX-TS", ts);

--- a/cpp/src/ws/client.cc
+++ b/cpp/src/ws/client.cc
@@ -32,7 +32,7 @@ std::vector<json> WSClient::on_open()
         std::string data = std::to_string(ts) + "websocket_login";
         std::string hmacced = encoding::hmac(std::string(api_secret), data, 32);
         std::string sign =
-          encoding::string_to_hex((unsigned char*)hmacced.c_str(), 32);
+          encoding::util_string_to_hex((unsigned char*)hmacced.c_str(), 32);
         json msg = {{"op", "login"},
                     {"args", {{"key", api_key}, {"sign", sign}, {"time", ts}}}};
         if (!subaccount_name.empty()) {


### PR DESCRIPTION
Add OpenSSL 1.1.x support (detection and API changes). Pull Request has two parts:

1. It adds OpenSSL detection, forces minimum OpenSSL version (1.1.x) and uses a more generic way of adding libraries. As stated in OpenSSL downloads page: "The latest stable version is the 1.1.1 series. This is also our Long Term Support (LTS) version, supported until 11th September 2023. All other versions (including 1.1.0, 1.0.2, 1.0.0 and 0.9.8) are now out of support and should not be used."

2. It renames `string_to_hex` function in `util` due to a name clash with a MACRO defined in OpenSSL (substituting `string_to_hex` with `OPENSSL_hexstr2buf `)

Tested on Ubuntu 18.04.4 LTS (gcc version 7.5.0) and macOS 10.14.6 (clang-1100.0.33.17)

```
Scanning dependencies of target rest
Scanning dependencies of target ws
Scanning dependencies of target util
[  9%] Building CXX object src/rest/CMakeFiles/rest.dir/client.cc.o
[ 18%] Building CXX object src/ws/CMakeFiles/ws.dir/client.cc.o
[ 27%] Building CXX object src/util/CMakeFiles/util.dir/HTTP.cc.o
[ 36%] Building CXX object src/util/CMakeFiles/util.dir/WS.cc.o
/Users/loki/devel/sentinel/ftx/ftx-ca508b4c8f36b76c1d6bc183714d6d6317ca6de7/cpp/src/util/HTTP.cc:110:17: fatal error: no member
      named 'OPENSSL_hexstr2buf' in namespace 'util::encoding'
      encoding::string_to_hex((unsigned char*)hmacced.c_str(), 32);
      ~~~~~~~~~~^
/Users/loki/devel/sentinel/release/x86_64/include/openssl/x509v3.h:635:24: note: expanded from macro 'string_to_hex'
# define string_to_hex OPENSSL_hexstr2buf
                       ^
1 error generated.
make[4]: *** [src/util/CMakeFiles/util.dir/HTTP.cc.o] Error 1
```