### PR TITLE
Fix 'unused lambda capture' errors.

### DIFF
--- a/cpp/src/util/WS.cc
+++ b/cpp/src/util/WS.cc
@@ -23,15 +23,15 @@ WS::WS()
           on_message_cb(j);
       });
 
-    wsclient.set_close_handler([this](websocketpp::connection_hdl) {
+    wsclient.set_close_handler([](websocketpp::connection_hdl) {
         std::cout << "connection closed";
     });
 
     wsclient.set_interrupt_handler(
-      [this](websocketpp::connection_hdl) { throw "Interrupt handler"; });
+      [](websocketpp::connection_hdl) { throw "Interrupt handler"; });
 
     wsclient.set_fail_handler(
-      [this](websocketpp::connection_hdl) { throw "Fail handler"; });
+      [](websocketpp::connection_hdl) { throw "Fail handler"; });
 
     wsclient.set_tls_init_handler([](websocketpp::connection_hdl) {
         return websocketpp::lib::make_shared<boost::asio::ssl::context>(


### PR DESCRIPTION
Fix 'unused lambda capture' errors.

Tested on Ubuntu 18.04.4 LTS (gcc version 7.5.0) and macOS 10.14.6 (clang-1100.0.33.17)

```
Scanning dependencies of target ws
Scanning dependencies of target rest
Scanning dependencies of target util
[  9%] Building CXX object src/rest/CMakeFiles/rest.dir/client.cc.o
[ 18%] Building CXX object src/ws/CMakeFiles/ws.dir/client.cc.o
[ 27%] Building CXX object src/util/CMakeFiles/util.dir/HTTP.cc.o
[ 36%] Building CXX object src/util/CMakeFiles/util.dir/WS.cc.o
/Users/loki/devel/sentinel/ftx/ftx-ca508b4c8f36b76c1d6bc183714d6d6317ca6de7/cpp/src/util/WS.cc:26:33: fatal error: lambda capture
      'this' is not used [-Wunused-lambda-capture]
    wsclient.set_close_handler([this](websocketpp::connection_hdl) {
                                ^~~~
[ 45%] Linking CXX static library librest.a
[ 45%] Built target rest
[ 54%] Linking CXX static library libws.a
[ 54%] Built target ws
1 error generated.
make[4]: *** [src/util/CMakeFiles/util.dir/WS.cc.o] Error 1
make[3]: *** [src/util/CMakeFiles/util.dir/all] Error 2
make[2]: *** [all] Error 2
make[1]: *** [ftx_build] Error 2
make: *** [build] Error 1
```