### PR TITLE
bugfix: (string) is the same as string instead of list-like type

### DIFF
--- a/rest/client.py
+++ b/rest/client.py
@@ -125,7 +125,7 @@ class FtxClient:
         assert type in ('stop', 'take_profit', 'trailing_stop')
         assert type not in ('stop', 'take_profit') or trigger_price is not None, \
             'Need trigger prices for stop losses and take profits'
-        assert type not in ('trailing_stop') or (trigger_price is None and trail_value is not None), \
+        assert type not in ('trailing_stop',) or (trigger_price is None and trail_value is not None), \
             'Trailing stops need a trail value and cannot take a trigger price'
 
         return self._post('conditional_orders',


### PR DESCRIPTION
when type is set to "stop", the original assertion will break because (string) is the same as string itself and "trailing_stop" includes "stop" as a substring.