### PR TITLE
Fix place_conditional_order: missing params of trade type and trailValue

### DIFF
--- a/rest/client.py
+++ b/rest/client.py
@@ -132,8 +132,8 @@ class FtxClient:
 
         return self._post('conditional_orders',
                           {'market': market, 'side': side, 'triggerPrice': trigger_price,
-                           'size': size, 'reduceOnly': reduce_only, 'type': 'stop',
-                           'cancelLimitOnTrigger': cancel, 'orderPrice': limit_price})
+                           'size': size, 'reduceOnly': reduce_only, 'type': type,
+                           'cancelLimitOnTrigger': cancel, 'orderPrice': limit_price, 'trailValue': trail_value})
 
     def cancel_order(self, order_id: str) -> dict:
         return self._delete(f'orders/{order_id}')


### PR DESCRIPTION
So there're two errors in method place_conditional_order:
1. param type was fixed as 'stop'
2. param trailValue wasn't included in post request

This PR fixes them. 