### PR TITLE
ciso8601 optional

### DIFF
--- a/rest/client.py
+++ b/rest/client.py
@@ -4,8 +4,11 @@ from typing import Optional, Dict, Any, List
 
 from requests import Request, Session, Response
 import hmac
-from ciso8601 import parse_datetime
-
+try:
+    from ciso8601 import parse_datetime
+except ModuleNotFoundError:
+    print("Module ciso8601 not installed - fallback to dateutil.parser")
+    from dateutil.parser import isoparse as parse_datetime
 
 
 class FtxClient:


### PR DESCRIPTION
ciso8601 package is difficult to install on some platforms where C compiler isn’t available.
Overhead of standard data parsing is tiny compare to REST calls anyway. 